### PR TITLE
Bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ before_install:
 
 script:
   # check requirements
-  - travis_retry make requirements
+  - make requirements
   # before deploy rewrite docker-compose to use the private container
-  - travis_retry $makefile prepare-docker-compose s=${server_v} p=${proxy_v} r=${robot_v}
+  - $makefile prepare-docker-compose s=${server_v} p=${proxy_v} r=${robot_v}
   # before deploy rewrite makefile to use the private container
-  - travis_retry $makefile prepare-makefile r=${robot_v}
+  - $makefile prepare-makefile r=${robot_v}
   # build configuration
-  - travis_retry travis_retry docker run --name misp-robot-init --rm -ti -v $TRAVIS_BUILD_DIR:/srv/misp-dockerized dcso/misp-robot-private bash -c "scripts/build_config.sh --automated-build"
+  - docker run --name misp-robot-init --rm -ti -v $TRAVIS_BUILD_DIR:/srv/misp-dockerized dcso/misp-robot-private bash -c "scripts/build_config.sh --automated-build"
   # deploy env
-  - travis_retry make deploy
+  - make deploy
   # configure env
   - travis_retry make configure
   - travis_retry $makefile test

--- a/.travis/Makefile
+++ b/.travis/Makefile
@@ -13,7 +13,7 @@ test-travis:
 
 pull-all:
 	# pull all images and tags
-	$(foreach c, $(CONTAINER), docker pull -a dcso/misp-$(c)-private;)
+	$(foreach c, $(CONTAINER), docker pull -a dcso/misp-$(c)-private)
 
 clone-all:
 	# clone all repos
@@ -36,9 +36,7 @@ tag:
 	$(eval c := server)
 	$(eval search_tag := $(s))
 	$(eval image_id := $(shell docker images --format "{{.Repository}}:{{.Tag}}:{{.ID}}"|grep misp-$(c)-private:$(search_tag)|cut -d : -f 3|head -n 1;))
-	echo $(image_id);
 	$(eval image_tags := $(shell docker images --format "{{.Repository}}:{{.Tag}}:{{.ID}}"|grep $(image_id)|cut -d : -f 2;))
-	echo $(image_tags);
 	$(foreach tag, $(image_tags), \
 		docker tag dcso/misp-$(c)-private:$(search_tag) $(PUBLIC_REPO)-$(c):$(tag); \
 	)
@@ -46,9 +44,7 @@ tag:
 	$(eval c := proxy)
 	$(eval search_tag := $(p))
 	$(eval image_id := $(shell docker images --format "{{.Repository}}:{{.Tag}}:{{.ID}}"|grep misp-$(c)-private:$(search_tag)|cut -d : -f 3|head -n 1;))
-	echo $(image_id);
 	$(eval image_tags := $(shell docker images --format "{{.Repository}}:{{.Tag}}:{{.ID}}"|grep $(image_id)|cut -d : -f 2;))
-	echo $(image_tags);
 	$(foreach tag, $(image_tags), \
 		docker tag dcso/misp-$(c)-private:$(search_tag) $(PUBLIC_REPO)-$(c):$(tag); \
 	)
@@ -56,12 +52,12 @@ tag:
 	$(eval c := robot)
 	$(eval search_tag := $(r))
 	$(eval image_id := $(shell docker images --format "{{.Repository}}:{{.Tag}}:{{.ID}}"|grep misp-$(c)-private:$(search_tag)|cut -d : -f 3|head -n 1;))
-	echo $(image_id);
 	$(eval image_tags := $(shell docker images --format "{{.Repository}}:{{.Tag}}:{{.ID}}"|grep $(image_id)|cut -d : -f 2;))
-	echo $(image_tags);
 	$(foreach tag, $(image_tags), \
 		docker tag dcso/misp-$(c)-private:$(search_tag) $(PUBLIC_REPO)-$(c):$(tag); \
 	)
+	@echo "###########################################"
+	docker images
 
 test:
 	echo "$(curl -S -k https://localhost/users/login)"|grep Login

--- a/README.md
+++ b/README.md
@@ -78,13 +78,7 @@ After cloning the repository change the branch to the required, for example:
 $> git clone https://github.com/DCSO/MISP-dockerized.git && git checkout tags/2.4.88-beta.3
 ```
 
-### 2. look if all required components are installed
-**MISP dockerized** comes with a requirements script that checks if all components are installed, is the user part of the docker group and has the user the right permission on the github repository folder. Simply start:   
-```
-$> make requirements
-```
-
-### 3. Configure TLS Certificates and Diffie-Hellmann File (optional)
+### 2. Configure TLS Certificates and Diffie-Hellmann File (optional)
 Before you start the container, you have to setup the TLS certificates and the Diffie-Hellman file.  
 Please make sure that the **certificate** and **key** are in PEM-Format - recognizable in the first line:
 > "-----BEGIN CERTIFICATE-----"  
@@ -98,21 +92,27 @@ If all prerequsites are fulfilled, you can deploy them as follows:
 * Copy the Certificate **Chain** file to `./config/ssl/cert.pem`
 * (**OPTIONAL**) During installation Diffie-Hellman Params will be freshly build, but if you still want to create them yourself, use the following command <sup>[1](#weakdh)</sup> or copy your existing one to `./config/ssl/dhparams.pem`
 
-### 4. Start Docker Environment
+### 3. Start Docker Environment
 To start the deployment and build the configuration files and configure the whole environment, simply enter:
 ```
 $> make start
 ```
 We decided, that build config and deploy environment can be done in one step.
 
-#### 4.1 [OPTIONAL] Manual build config 
+#### 4.1 look if all required components are installed
+**MISP dockerized** comes with a requirements script that checks if all components are installed, is the user part of the docker group and has the user the right permission on the github repository folder. Simply start:   
+```
+$> make requirements
+```
+
+#### 4.2 [OPTIONAL] Manual build config 
 If you want to do it manual: **MISP dockerized** comes with a build script that creates all required config files. Simply start:   
 ```
 $> make build-config
 ```
 The build script download our DCSO/misp-robot and start him with the build script. Therefore you can't find the script directly in the github repository.
 
-#### 4.2 [OPTIONAL] Manual deploy environment
+#### 4.3 [OPTIONAL] Manual deploy environment
 To start the deployment process, simply enter:
 ```
 $> make deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ version: '3.1'
 networks: 
   misp-backend:
     driver: bridge
+    ipam:
+      config:
+      - subnet: 192.168.47.0/28
 
 services:
   ### MISP Database ###
@@ -43,7 +46,7 @@ services:
       timeout: 15s
       retries: 3
     volumes:
-      - misp-vol-redis-data:/data/"
+      - misp-vol-redis-data:/data/
     networks:
       misp-backend:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
 
   ### MISP Apache Server ###    
   misp-server:
-    image: dcso/misp-server:2.4.88    
+    image: dcso/misp-server:2.4.89    
     container_name: misp-server
     depends_on:
       - "misp-db"


### PR DESCRIPTION
- changed docker-compose network
  Reason:
  In standard docker create a 172.x.0.0/16 Network. This can collidate with an existing one.
  Therefore we add the option to change the own docker network on your self on your reuqirements. Additionally we change our default network subnet to 192.168.47.0/28. We hope we can reduce the collisions with other networks. In Future we want to add this in our build configuration script.