### PR TITLE
Bug.MDD141 -     wrong common name on certificate after installation & `make change-ssl`does not work

### DIFF
--- a/1.0.0/Makefile
+++ b/1.0.0/Makefile
@@ -141,7 +141,9 @@ configure:
 	make config-smime
 	make config-pgp
 config-ssl:
-	docker cp $(CURDIR)/config/ssl/. misp-server:/etc/apache/ssl
+	docker cp $(CURDIR)/config/ssl/. misp-proxy:/etc/nginx/ssl/
+	docker cp misp-proxy:/etc/nginx/ssl/. $(CURDIR)/config/ssl/
+	rm $(CURDIR)/config/ssl/misp-dockerized*
 	docker restart misp-server
 	docker restart misp-proxy
 config-smime:

--- a/1.0.0/example/crontab.txt
+++ b/1.0.0/example/crontab.txt
@@ -1,0 +1,2 @@
+# Patch once a week the container
+@weekly 		make -C /opt/MISP-dockerized deploy

--- a/1.0.0/scripts/build_config.sh
+++ b/1.0.0/scripts/build_config.sh
@@ -233,28 +233,28 @@ function query_http_settings(){
   read -p "Which HTTP Serveradmin mailadress should we use [DEFAULT: $HTTP_SERVERADMIN]: " -ei "$HTTP_SERVERADMIN" HTTP_SERVERADMIN
   read -p "How much PHP memory should be used? [DEFAULT: $PHP_MEMORY]: " -ei $PHP_MEMORY  PHP_MEMORY
 
-  ### DEACTIVATED
-  # while (true)
-  # do
-  #   read -r -p "Should we allow access to misp from every IP? [y/N] " -ei "$ALLOW_ALL_IPs" ALLOW_ALL_IPs
-  #   case $ALLOW_ALL_IPs in
-  #     [yY][eE][sS]|[yY])
-  #       ALLOW_ALL_IPs=yes
-  #       break
-  #       ;;
-  #     [nN][oO]|[nN])
-  #       ALLOW_ALL_IPs=no
-  #       read -p "Which IPs should have access? [DEFAULT: 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8]: " -ei "$HTTP_ALLOWED_IP" HTTP_ALLOWED_IP
-  #       break
-  #       ;;
-  #     [eE][xX][iI][tT])
-  #       exit 1
-  #       ;;
-  #     *)
-  #       echo -e "\nplease only choose [y|n] for the question!\n"
-  #     ;;
-  #   esac
-  # done
+  while (true)
+  do
+    read -r -p "Should we allow access to misp from every IP? [y/N] " -ei "$ALLOW_ALL_IPs" ALLOW_ALL_IPs
+    case $ALLOW_ALL_IPs in
+      [yY][eE][sS]|[yY])
+        ALLOW_ALL_IPs=yes
+        HTTP_ALLOWED_IP="all"
+        break
+        ;;
+      [nN][oO]|[nN])
+        ALLOW_ALL_IPs=no
+        read -p "Which IPs should have access? [DEFAULT: 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8]: " -ei "$HTTP_ALLOWED_IP" HTTP_ALLOWED_IP
+        break
+        ;;
+      [eE][xX][iI][tT])
+        exit 1
+        ;;
+      *)
+        echo -e "\nplease only choose [y|n] for the question!\n"
+      ;;
+    esac
+  done
 }
 
 # Questions for MISP Settings into MISP-server
@@ -534,6 +534,7 @@ services:
       HTTP_PROXY: ${HTTP_PROXY}
       HTTPS_PROXY: ${HTTPS_PROXY}
       NO_PROXY: ${NO_PROXY}
+      IP: ${HTTP_ALLOWED_IP}
     ${LOG_SETTINGS}
 
   misp-robot:


### PR DESCRIPTION
## Changelog for bug.MDD141 - Wrong common name in the certificate after installation & `make change-ssl`does not work

### Update  
We fixed Makefile and updated build_script.sh to fix the issue only on 1.0.0.

### General changes
No general changes were made.

### Corrections & Improvements
- Change build_script Version 1.0.0
- Change Makefile Version 1.0.0

### Detailed changes
- We have adapted the Makefile so that it is now able to copy a local certificate into the misp-proxy and the misp-server and to copy the certificate from there as well.
- We add the IP protect feature for NGINX. With this feature you can only allow selected IP addresses.